### PR TITLE
Update to Ubuntu 24.04, produce Linux aarch64 targets

### DIFF
--- a/.github/workflows/check-new-releases.yaml
+++ b/.github/workflows/check-new-releases.yaml
@@ -1,11 +1,11 @@
 name: Check for new releases
+#on:
+#  schedule:
+#    - cron:  '0 * * * *'
 on:
-  schedule:
-    - cron:  '0 * * * *'
-# on:
-#   push:
-#     branches:
-#       - main
+  push:
+    branches:
+      - feature/architectures
 
 jobs:
   check-new-01-releases:

--- a/.github/workflows/hc-binaries.yaml
+++ b/.github/workflows/hc-binaries.yaml
@@ -10,7 +10,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        platform: [windows-2019, macos-latest, ubuntu-22.04]
+        platform: [windows-2019, macos-latest, ubuntu-24.04]
     permissions:
       contents: write
     runs-on: ${{ matrix.platform }}
@@ -76,12 +76,21 @@ jobs:
           gh release upload "hc-binaries-${{ inputs.hc-version }}" "hc-v${{ inputs.hc-version }}-aarch64-apple-darwin"
 
       - name: setup binaries (ubuntu only)
-        if: matrix.platform == 'ubuntu-22.04'
+        if: matrix.platform == 'ubuntu-24.04'
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          cargo install holochain_cli --version ${{ inputs.hc-version }} --locked
+          rustup target add x86_64-unknown-linux-gnu
+          rustup target add aarch64-unknown-linux-gnu
+
+          cargo install holochain_cli --version ${{ inputs.hc-version }} --target x86_64-unknown-linux-gnu --locked
           HC_PATH=$(which hc)
           cp $HC_PATH hc-v${{ inputs.hc-version }}-x86_64-unknown-linux-gnu
 
           gh release upload "hc-binaries-${{ inputs.hc-version }}" "hc-v${{ inputs.hc-version }}-x86_64-unknown-linux-gnu"
+
+          cargo install holochain_cli --version ${{ inputs.hc-version }} --target aarch64-unknown-linux-gnu --locked
+          HC_PATH=$(which hc)
+          cp $HC_PATH hc-v${{ inputs.hc-version }}-aarch64-unknown-linux-gnu
+
+          gh release upload "hc-binaries-${{ inputs.hc-version }}" "hc-v${{ inputs.hc-version }}-aarch64-unknown-linux-gnu"

--- a/.github/workflows/holochain-binaries.yaml
+++ b/.github/workflows/holochain-binaries.yaml
@@ -10,7 +10,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        platform: [windows-2019, macos-latest, macos-13, ubuntu-22.04]
+        platform: [windows-2019, macos-latest, ubuntu-24.04]
     permissions:
       contents: write
     runs-on: ${{ matrix.platform }}
@@ -62,22 +62,8 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          rustup target add aarch64-apple-darwin
-
-          cargo install holochain --version ${{ inputs.holochain-version }} --target aarch64-apple-darwin --locked
-          HOLOCHAIN_PATH=$(which holochain)
-          cp $HOLOCHAIN_PATH holochain-v${{ inputs.holochain-version }}-aarch64-apple-darwin
-
-          shasum -a 256 holochain-v${{ inputs.holochain-version }}-aarch64-apple-darwin
-
-          gh release upload "holochain-binaries-${{ inputs.holochain-version }}" "holochain-v${{ inputs.holochain-version }}-aarch64-apple-darwin"
-
-      - name: setup binaries (macos-13 only)
-        if: matrix.platform == 'macos-13'
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: |
           rustup target add x86_64-apple-darwin
+          rustup target add aarch64-apple-darwin
 
           cargo install holochain --version ${{ inputs.holochain-version }} --target x86_64-apple-darwin --locked
           HOLOCHAIN_PATH=$(which holochain)
@@ -87,15 +73,34 @@ jobs:
 
           gh release upload "holochain-binaries-${{ inputs.holochain-version }}" "holochain-v${{ inputs.holochain-version }}-x86_64-apple-darwin"
 
+          cargo install holochain --version ${{ inputs.holochain-version }} --target aarch64-apple-darwin --locked
+          HOLOCHAIN_PATH=$(which holochain)
+          cp $HOLOCHAIN_PATH holochain-v${{ inputs.holochain-version }}-aarch64-apple-darwin
+
+          shasum -a 256 holochain-v${{ inputs.holochain-version }}-aarch64-apple-darwin
+
+          gh release upload "holochain-binaries-${{ inputs.holochain-version }}" "holochain-v${{ inputs.holochain-version }}-aarch64-apple-darwin"
+
       - name: setup binaries (ubuntu only)
-        if: matrix.platform == 'ubuntu-22.04'
+        if: matrix.platform == 'ubuntu-24.04'
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          cargo install holochain --version ${{ inputs.holochain-version }} --locked
+          rustup target add x86_64-unknown-linux-gnu
+          rustup target add aarch64-unknown-linux-gnu
+
+          cargo install holochain --version ${{ inputs.holochain-version }} --target x86_64-unknown-linux-gnu --locked
           HOLOCHAIN_PATH=$(which holochain)
           cp $HOLOCHAIN_PATH holochain-v${{ inputs.holochain-version }}-x86_64-unknown-linux-gnu
 
           shasum -a 256 holochain-v${{ inputs.holochain-version }}-x86_64-unknown-linux-gnu
 
           gh release upload "holochain-binaries-${{ inputs.holochain-version }}" "holochain-v${{ inputs.holochain-version }}-x86_64-unknown-linux-gnu"
+
+          cargo install holochain --version ${{ inputs.holochain-version }} --target aarch64-unknown-linux-gnu --locked
+          HOLOCHAIN_PATH=$(which holochain)
+          cp $HOLOCHAIN_PATH holochain-v${{ inputs.holochain-version }}-aarch64-unknown-linux-gnu
+
+          shasum -a 256 holochain-v${{ inputs.holochain-version }}-aarch64-unknown-linux-gnu
+
+          gh release upload "holochain-binaries-${{ inputs.holochain-version }}" "holochain-v${{ inputs.holochain-version }}-aarch64-unknown-linux-gnu"

--- a/.github/workflows/lair-binaries.yaml
+++ b/.github/workflows/lair-binaries.yaml
@@ -10,7 +10,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        platform: [windows-2019, macos-latest, macos-13, ubuntu-22.04]
+        platform: [windows-2019, macos-latest, ubuntu-24.04]
     permissions:
       contents: write
     runs-on: ${{ matrix.platform }}
@@ -55,20 +55,8 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          rustup target add aarch64-apple-darwin
-
-          cargo install lair_keystore --version ${{ inputs.lair-version }} --target aarch64-apple-darwin
-          LAIR_PATH=$(which lair-keystore)
-          cp $LAIR_PATH lair-keystore-v${{ inputs.lair-version }}-aarch64-apple-darwin
-          shasum -a 256 lair-keystore-v${{ inputs.lair-version }}-aarch64-apple-darwin
-          gh release upload "lair-binaries-${{ inputs.lair-version }}" "lair-keystore-v${{ inputs.lair-version }}-aarch64-apple-darwin"
-
-      - name: setup binaries (macos-13 only)
-        if: matrix.platform == 'macos-13'
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: |
           rustup target add x86_64-apple-darwin
+          rustup target add aarch64-apple-darwin
 
           cargo install lair_keystore --version ${{ inputs.lair-version }} --target x86_64-apple-darwin
           LAIR_PATH=$(which lair-keystore)
@@ -76,14 +64,28 @@ jobs:
           shasum -a 256 lair-keystore-v${{ inputs.lair-version }}-x86_64-apple-darwin
           gh release upload "lair-binaries-${{ inputs.lair-version }}" "lair-keystore-v${{ inputs.lair-version }}-x86_64-apple-darwin"
 
+          cargo install lair_keystore --version ${{ inputs.lair-version }} --target aarch64-apple-darwin
+          LAIR_PATH=$(which lair-keystore)
+          cp $LAIR_PATH lair-keystore-v${{ inputs.lair-version }}-aarch64-apple-darwin
+          shasum -a 256 lair-keystore-v${{ inputs.lair-version }}-aarch64-apple-darwin
+          gh release upload "lair-binaries-${{ inputs.lair-version }}" "lair-keystore-v${{ inputs.lair-version }}-aarch64-apple-darwin"
 
       - name: setup binaries (ubuntu only)
-        if: matrix.platform == 'ubuntu-22.04'
+        if: matrix.platform == 'ubuntu-24.04'
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          cargo install lair_keystore --version ${{ inputs.lair-version }}
+          rustup target add x86_64-unknown-linux-gnu
+          rustup target add aarch64-unknown-linux-gnu
+
+          cargo install lair_keystore --version ${{ inputs.lair-version }} --target x86_64-unknown-linux-gnu
           LAIR_PATH=$(which lair-keystore)
           cp $LAIR_PATH lair-keystore-v${{ inputs.lair-version }}-x86_64-unknown-linux-gnu
           shasum -a 256 lair-keystore-v${{ inputs.lair-version }}-x86_64-unknown-linux-gnu
           gh release upload "lair-binaries-${{ inputs.lair-version }}" "lair-keystore-v${{ inputs.lair-version }}-x86_64-unknown-linux-gnu"
+
+          cargo install lair_keystore --version ${{ inputs.lair-version }} --target aarch64-unknown-linux-gnu
+          LAIR_PATH=$(which lair-keystore)
+          cp $LAIR_PATH lair-keystore-v${{ inputs.lair-version }}-aarch64-unknown-linux-gnu
+          shasum -a 256 lair-keystore-v${{ inputs.lair-version }}-aarch64-unknown-linux-gnu
+          gh release upload "lair-binaries-${{ inputs.lair-version }}" "lair-keystore-v${{ inputs.lair-version }}-aarch64-unknown-linux-gnu"

--- a/scripts/check-new-04-releases.mjs
+++ b/scripts/check-new-04-releases.mjs
@@ -13,7 +13,8 @@ const holochainReleasesOptions = {
 const binariesTagsOptions = {
   hostname: 'api.github.com',
   port: 443,
-  path: '/repos/matthme/holochain-binaries/tags',
+  // path: '/repos/matthme/holochain-binaries/tags',
+  path: '/repos/pjkundert/holochain-binaries/tags',  // revert before merge!
   method: 'GET',
   headers: {
     'User-Agent': 'Holochain Binaries'

--- a/scripts/check-new-hc-releases.mjs
+++ b/scripts/check-new-hc-releases.mjs
@@ -13,7 +13,8 @@ const hcCrateOptions = {
 const binariesTagsOptions = {
   hostname: 'api.github.com',
   port: 443,
-  path: '/repos/matthme/holochain-binaries/git/refs/tags',
+  // path: '/repos/matthme/holochain-binaries/git/refs/tags',
+  path: '/repos/pjkundert/holochain-binaries/git/refs/tags',  // revert before merge!
   method: 'GET',
   headers: {
     'User-Agent': 'Holochain Binaries'

--- a/scripts/check-new-lair-releases.mjs
+++ b/scripts/check-new-lair-releases.mjs
@@ -13,7 +13,8 @@ const lairCrateOptions = {
 const binariesTagsOptions = {
   hostname: 'api.github.com',
   port: 443,
-  path: '/repos/matthme/holochain-binaries/tags',
+  // path: '/repos/matthme/holochain-binaries/tags',
+  path: '/repos/pjkundert/holochain-binaries/tags',  // revert before merge!
   method: 'GET',
   headers: {
     'User-Agent': 'Holochain Binaries'


### PR DESCRIPTION
I'd like to get binaries built for aarch64 on Linux;
- Update to Ubuntu 24.04 w/ both x86_64 and aarch64 targets
- Generate all targets on macos-latest for consistency instead of macos-13

This is a Work In-Progress, and I'm not sure if this approach will work for all aarch64/x86_64 targets on both ubuntu-24.04 and macos-latest...